### PR TITLE
Update Backstage demo service name references in installation guides

### DIFF
--- a/docs/getting-started/multi-cluster.mdx
+++ b/docs/getting-started/multi-cluster.mdx
@@ -359,21 +359,21 @@ Verify the installation:
 kubectl get pods -l app.kubernetes.io/name=backstage -n openchoreo-control-plane --context kind-openchoreo-cp
 
 # Check service
-kubectl get svc openchoreo-backstage-demo -n openchoreo-control-plane --context kind-openchoreo-cp
+kubectl get svc backstage-demo -n openchoreo-control-plane --context kind-openchoreo-cp
 ```
 
 To access the Backstage portal:
 
 ```bash
 # Port forward the Backstage service in background and open browser
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
 
 # Or if you prefer to manually open the browser:
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2
 # Then access in browser at http://localhost:7007
 
 # To stop the port-forward when done:
-pkill -f "kubectl port-forward.*openchoreo-backstage-demo.*7007:7007"
+pkill -f "kubectl port-forward.*backstage-demo.*7007:7007"
 ```
 
 You can verify the portal is working correctly with curl:

--- a/docs/getting-started/single-cluster.mdx
+++ b/docs/getting-started/single-cluster.mdx
@@ -303,21 +303,21 @@ Verify the installation:
 kubectl get pods -l app.kubernetes.io/name=backstage -n openchoreo-control-plane
 
 # Check service
-kubectl get svc openchoreo-backstage-demo -n openchoreo-control-plane
+kubectl get svc backstage-demo -n openchoreo-control-plane
 ```
 
 To access the Backstage portal:
 
 ```bash
 # Port forward the Backstage service in background and open browser
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
 
 # Or if you prefer to manually open the browser:
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2
 # Then access in browser at http://localhost:7007
 
 # To stop the port-forward when done:
-pkill -f "kubectl port-forward.*openchoreo-backstage-demo.*7007:7007"
+pkill -f "kubectl port-forward.*backstage-demo.*7007:7007"
 ```
 
 You can verify the portal is working correctly with curl:

--- a/versioned_docs/version-v0.3.x/getting-started/multi-cluster.mdx
+++ b/versioned_docs/version-v0.3.x/getting-started/multi-cluster.mdx
@@ -359,21 +359,21 @@ Verify the installation:
 kubectl get pods -l app.kubernetes.io/name=backstage -n openchoreo-control-plane --context kind-openchoreo-cp
 
 # Check service
-kubectl get svc openchoreo-backstage-demo -n openchoreo-control-plane --context kind-openchoreo-cp
+kubectl get svc backstage-demo -n openchoreo-control-plane --context kind-openchoreo-cp
 ```
 
 To access the Backstage portal:
 
 ```bash
 # Port forward the Backstage service in background and open browser
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
 
 # Or if you prefer to manually open the browser:
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 --context kind-openchoreo-cp > /dev/null 2>&1 & sleep 2
 # Then access in browser at http://localhost:7007
 
 # To stop the port-forward when done:
-pkill -f "kubectl port-forward.*openchoreo-backstage-demo.*7007:7007"
+pkill -f "kubectl port-forward.*backstage-demo.*7007:7007"
 ```
 
 You can verify the portal is working correctly with curl:

--- a/versioned_docs/version-v0.3.x/getting-started/single-cluster.mdx
+++ b/versioned_docs/version-v0.3.x/getting-started/single-cluster.mdx
@@ -303,21 +303,21 @@ Verify the installation:
 kubectl get pods -l app.kubernetes.io/name=backstage -n openchoreo-control-plane
 
 # Check service
-kubectl get svc openchoreo-backstage-demo -n openchoreo-control-plane
+kubectl get svc backstage-demo -n openchoreo-control-plane
 ```
 
 To access the Backstage portal:
 
 ```bash
 # Port forward the Backstage service in background and open browser
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2 && open http://localhost:7007
 
 # Or if you prefer to manually open the browser:
-kubectl port-forward -n openchoreo-control-plane svc/openchoreo-backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2
+kubectl port-forward -n openchoreo-control-plane svc/backstage-demo 7007:7007 > /dev/null 2>&1 & sleep 2
 # Then access in browser at http://localhost:7007
 
 # To stop the port-forward when done:
-pkill -f "kubectl port-forward.*openchoreo-backstage-demo.*7007:7007"
+pkill -f "kubectl port-forward.*backstage-demo.*7007:7007"
 ```
 
 You can verify the portal is working correctly with curl:


### PR DESCRIPTION
## Purpose
Fixed kubectl commands to use correct service name 'backstage-demo' instead of 'openchoreo-backstage-demo' in both single-cluster and multi-cluster installation guides.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)
