### PR TITLE
Fix list rendering issue in the architecture page

### DIFF
--- a/docs/overview/architecture.mdx
+++ b/docs/overview/architecture.mdx
@@ -29,11 +29,11 @@ Each plane in OpenChoreo operates as a distinct functional unit, with its own li
 The brain of OpenChoreo. It watches developer- and platform-defined CRDs, validates and processes them, and coordinates activities across other planes. It translates intent such as "deploy this component" or "connect these services" into concrete infrastructure actions. 
 
 Responsibilities include:
-	•	Validating CRD instances and resolving references (e.g., Connections between Components)
-	•	Applying policy and environment-specific rules
-	•	Coordinating CI jobs, deployments, and observability configurations
-	•	Reconciling desired state with actual state across all planes
-	•	Tracking the state of Components across environments and Data Planes
+- Validating CRD instances and resolving references (e.g., Connections between Components)
+- Applying policy and environment-specific rules
+- Coordinating CI jobs, deployments, and observability configurations
+- Reconciling desired state with actual state across all planes
+- Tracking the state of Components across environments and Data Planes
 
 The Control Plane is extensible, allowing integration with different backends for image building, observability tooling, environment provisioning, and more.
 

--- a/docs/overview/what-is-openchoreo.mdx
+++ b/docs/overview/what-is-openchoreo.mdx
@@ -10,7 +10,7 @@ import {versions} from '../_constants.mdx';
 # What is OpenChoreo?
 OpenChoreo is a comprehensive, open-source Internal Developer Platform (IDP) designed for platform engineering (PE) teams who want to streamline developer workflows and deliver Internal Developer Portals without having to build everything from scratch.
 
-OpenChoreo orchestrates many CNCF and other projects to provide a comprehensive framework for PE teams to build the platform they want.
+OpenChoreo orchestrates many CNCF and other projects to give platform teams a strong head start, you can use it as-is, or tailor it to fit your own internal developer platform vision. 
 
 ## Why OpenChoreo?
 

--- a/versioned_docs/version-v0.3.x/overview/architecture.mdx
+++ b/versioned_docs/version-v0.3.x/overview/architecture.mdx
@@ -13,7 +13,7 @@ OpenChoreo is architected as a modular, Kubernetes-native control plane that int
 The Control Plane acts as the orchestrator, transforming high-level platform and developer intent into actionable workloads deployed across Data Planes, while wiring them into the Observability Plane for visibility.
 
 The diagram below illustrates how these components interact.
-xz
+
 ![](../resources/openchoreo_components.svg)
 
 Each plane in OpenChoreo operates as a distinct functional unit, with its own lifecycle, scaling behavior, and security boundaries. Together, these planes and supporting interfaces form the core components of the platform:
@@ -29,11 +29,11 @@ Each plane in OpenChoreo operates as a distinct functional unit, with its own li
 The brain of OpenChoreo. It watches developer- and platform-defined CRDs, validates and processes them, and coordinates activities across other planes. It translates intent such as "deploy this component" or "connect these services" into concrete infrastructure actions. 
 
 Responsibilities include:
-	•	Validating CRD instances and resolving references (e.g., Connections between Components)
-	•	Applying policy and environment-specific rules
-	•	Coordinating CI jobs, deployments, and observability configurations
-	•	Reconciling desired state with actual state across all planes
-	•	Tracking the state of Components across environments and Data Planes
+- Validating CRD instances and resolving references (e.g., Connections between Components)
+- Applying policy and environment-specific rules
+- Coordinating CI jobs, deployments, and observability configurations
+- Reconciling desired state with actual state across all planes
+- Tracking the state of Components across environments and Data Planes
 
 The Control Plane is extensible, allowing integration with different backends for image building, observability tooling, environment provisioning, and more.
 

--- a/versioned_docs/version-v0.3.x/overview/what-is-openchoreo.mdx
+++ b/versioned_docs/version-v0.3.x/overview/what-is-openchoreo.mdx
@@ -10,7 +10,7 @@ import {versions} from '../_constants.mdx';
 # What is OpenChoreo?
 OpenChoreo is a comprehensive, open-source Internal Developer Platform (IDP) designed for platform engineering (PE) teams who want to streamline developer workflows and deliver Internal Developer Portals without having to build everything from scratch.
 
-OpenChoreo orchestrates many CNCF and other projects to provide a comprehensive framework for PE teams to build the platform they want.
+OpenChoreo orchestrates many CNCF and other projects to give platform teams a strong head start, you can use it as-is, or tailor it to fit your own internal developer platform vision. 
 
 ## Why OpenChoreo?
 


### PR DESCRIPTION
## Purpose
There was a list rendering issue due to incorrect Markdown syntax in the architecture page. 

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
