### PR TITLE
docs(ecosystem): rename openchoreo-import skill to migrate-to-openchoreo

### DIFF
--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -916,9 +916,9 @@
     "released": true
   },
   {
-    "id": "skill-openchoreo-import",
+    "id": "skill-migrate-to-openchoreo",
     "group": "skill",
-    "name": "OpenChoreo Import",
+    "name": "Migrate to OpenChoreo",
     "description": "Plans an OpenChoreo migration from a Helm chart, Kustomize overlay, Docker Compose file, or raw Kubernetes YAML. Renders the source, classifies what fits OpenChoreo's primitives, surfaces a fit verdict, and produces an interactive plan with per-Project apply steps. Plans only — never applies to a cluster.",
     "category": "AI",
     "tags": [
@@ -930,7 +930,7 @@
     ],
     "logoUrl": "",
     "author": "OpenChoreo",
-    "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/openchoreo-import",
+    "sourceUrl": "https://github.com/openchoreo/skills/tree/main/skills/migrate-to-openchoreo",
     "default": false,
     "released": true
   },


### PR DESCRIPTION
## Purpose
Rename the `openchoreo-import` skill to `migrate-to-openchoreo` in the ecosystem marketplace listing (`id`, `name`, `sourceUrl`), matching the skill rename in `openchoreo/skills`.

## Related Issues
N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page — N/A, data-only change
- [ ] Run `npm run start` to preview the changes locally
- [ ] Run `npm run build` to ensure the build passes without errors
- [ ] Verified all links are working (no broken links)

> Note: `sourceUrl` resolves once openchoreo/skills#23 merges.
