### PR TITLE
fix(ecosystem): render GitHub alerts as admonitions

### DIFF
--- a/src/components/EcosystemItem/index.tsx
+++ b/src/components/EcosystemItem/index.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import Layout from '@theme/Layout';
+import Admonition from '@theme/Admonition';
 import Link from '@docusaurus/Link';
 import { useLocation } from '@docusaurus/router';
 import ReactMarkdown from 'react-markdown';
@@ -354,8 +355,52 @@ function resolveUrl(src: string, rawBaseUrl: string): string {
   }
 }
 
+// GitHub alert markers (> [!WARNING]) mapped to Docusaurus admonition types, so a
+// README renders the same callouts here as it does on GitHub.
+const GITHUB_ALERT_TYPES: Record<string, string> = {
+  NOTE: 'note',
+  TIP: 'tip',
+  IMPORTANT: 'info',
+  WARNING: 'warning',
+  CAUTION: 'danger',
+};
+
+// remark-gfm does not implement GitHub alerts, so they arrive as plain blockquotes
+// with a literal "[!WARNING]" prefix. This rewrites those into an `admonition` node
+// that createMdComponents renders with the theme's own Admonition component.
+function remarkGithubAlerts() {
+  return (tree: any) => {
+    const walk = (node: any) => {
+      if (node.type === 'blockquote') {
+        const paragraph = node.children?.[0];
+        const text = paragraph?.type === 'paragraph' ? paragraph.children?.[0] : undefined;
+        const match =
+          text?.type === 'text'
+            ? /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*\r?\n?/.exec(text.value)
+            : null;
+        if (match) {
+          text.value = text.value.slice(match[0].length);
+          if (!text.value) {
+            paragraph.children.shift();
+          }
+          node.data = {
+            ...node.data,
+            hName: 'admonition',
+            hProperties: { type: GITHUB_ALERT_TYPES[match[1]] },
+          };
+        }
+      }
+      node.children?.forEach(walk);
+    };
+    walk(tree);
+  };
+}
+
 function createMdComponents(rawBaseUrl: string) {
   return {
+    admonition({ type, children }: { type?: string; children?: ReactNode }) {
+      return <Admonition type={type ?? 'note'}>{children}</Admonition>;
+    },
     pre({ children }: { children?: ReactNode }) {
       return <>{children}</>;
     },
@@ -751,7 +796,7 @@ export default function EcosystemItem(): ReactNode {
                             ))
                           ) : (
                             <ReactMarkdown
-                              remarkPlugins={[remarkGfm]}
+                              remarkPlugins={[remarkGfm, remarkGithubAlerts]}
                               components={marketplaceMdComponents as any}
                             >
                               {section.body}
@@ -790,7 +835,10 @@ export default function EcosystemItem(): ReactNode {
                 {parsed.intro && (
                   <div className={styles.introCard}>
                     <div className={styles.markdownContent}>
-                      <ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents as any}>
+                      <ReactMarkdown
+                        remarkPlugins={[remarkGfm, remarkGithubAlerts]}
+                        components={mdComponents as any}
+                      >
                         {parsed.intro}
                       </ReactMarkdown>
                     </div>
@@ -898,7 +946,7 @@ export default function EcosystemItem(): ReactNode {
                         )}
                         <div className={styles.markdownContent}>
                           <ReactMarkdown
-                            remarkPlugins={[remarkGfm]}
+                            remarkPlugins={[remarkGfm, remarkGithubAlerts]}
                             components={mdComponents as any}
                           >
                             {activeSection.content}

--- a/src/components/EcosystemItem/index.tsx
+++ b/src/components/EcosystemItem/index.tsx
@@ -381,7 +381,12 @@ function remarkGithubAlerts() {
         if (match) {
           text.value = text.value.slice(match[0].length);
           if (!text.value) {
+            // The marker sat on its own; drop it, and the paragraph too if that
+            // emptied it, which is the case for the multi-paragraph alert form.
             paragraph.children.shift();
+            if (paragraph.children.length === 0) {
+              node.children.shift();
+            }
           }
           node.data = {
             ...node.data,


### PR DESCRIPTION
## Purpose

Module READMEs use GitHub alert syntax (`> [!WARNING]`, `> [!NOTE]`, and so on). The ecosystem item
page renders those READMEs with `react-markdown` and `remark-gfm`, which does not implement alerts,
so the marker showed up as literal text at the start of a plain blockquote.

**Changes**

- Add a small remark plugin in `EcosystemItem` that finds blockquotes opening with an alert marker,
  strips the marker, and rewrites the node as an `admonition`
- Render those nodes with `@theme/Admonition`, so they use the same styling as the `:::warning`
  admonitions in the docs rather than a bespoke callout
- Wire the plugin into the three `ReactMarkdown` call sites that render README content

`IMPORTANT` maps to the `info` admonition and `CAUTION` to `danger`, since Docusaurus has no direct
equivalent for either. No new dependency: the plugin walks the tree directly rather than pulling in
`unist-util-visit`, which is only present transitively.

## Related Issues

N/A

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)