### PR TITLE
feat(ecosystem): add Backstage as a Developer Portal module

### DIFF
--- a/src/components/EcosystemItem/index.tsx
+++ b/src/components/EcosystemItem/index.tsx
@@ -22,6 +22,7 @@ interface Plugin {
   logoUrl?: string;
   author: string;
   sourceUrl?: string;
+  overviewUrl?: string;
   default?: boolean;
   released?: boolean;
 }
@@ -936,16 +937,28 @@ export default function EcosystemItem(): ReactNode {
                     ? 'Documentation for this item is available externally.'
                     : 'No documentation available yet.'}
                 </p>
-                {plugin.sourceUrl && (
-                  <a
-                    href={plugin.sourceUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className={styles.stateLink}
-                  >
-                    View Documentation →
-                  </a>
-                )}
+                <div className={styles.stateLinkRow}>
+                  {plugin.sourceUrl && (
+                    <a
+                      href={plugin.sourceUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.stateLink}
+                    >
+                      View Documentation →
+                    </a>
+                  )}
+                  {plugin.overviewUrl && (
+                    <a
+                      href={plugin.overviewUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.stateLink}
+                    >
+                      Screenshots and features →
+                    </a>
+                  )}
+                </div>
               </div>
             )}
             </div>{/* end .card */}

--- a/src/components/EcosystemItem/styles.module.css
+++ b/src/components/EcosystemItem/styles.module.css
@@ -604,6 +604,13 @@
   color: var(--ifm-color-emphasis-600);
 }
 
+.stateLinkRow {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.25rem;
+}
+
 .stateLink {
   font-size: 0.9rem;
   color: var(--ifm-color-primary);

--- a/src/data/marketplace-plugins.json
+++ b/src/data/marketplace-plugins.json
@@ -144,6 +144,25 @@
     "released": true
   },
   {
+    "id": "backstage",
+    "group": "module",
+    "name": "Backstage",
+    "description": "Backstage-based OpenChoreo portal. The default UI for the platform, with a synced catalog, component views, and self-service templates on top of the OpenChoreo API.",
+    "category": "Developer Portal",
+    "tags": [
+      "portal",
+      "backstage",
+      "developer-portal",
+      "catalog"
+    ],
+    "logoUrl": "/img/logos/tech-logo-backstage.webp",
+    "author": "OpenChoreo",
+    "sourceUrl": "https://openchoreo.dev/docs/platform-engineer-guide/backstage-plugins/overview/",
+    "overviewUrl": "https://openchoreo.dev/explore/backstage-powered-developer-portal/",
+    "default": true,
+    "released": true
+  },
+  {
     "id": "tekton-pipelines",
     "group": "module",
     "name": "Tekton Pipelines",


### PR DESCRIPTION
## Purpose

Adds Backstage to the ecosystem catalog under a new **Developer Portal** category.
<img width="1728" height="897" alt="Screenshot 2026-08-20 at 07 32 48" src="https://github.com/user-attachments/assets/4ac23473-dd91-4646-b44d-bd2ece64fb9f" />
<img width="1728" height="897" alt="Screenshot 2026-08-20 at 07 33 02" src="https://github.com/user-attachments/assets/68f40639-951b-4df3-affd-55d4854fcef3" />



- New entry in `src/data/marketplace-plugins.json`. Categories are derived from the data at runtime, so the new category needed no code change — future portal entries go in the same one.
- `sourceUrl` points at the Backstage plugins docs and the logo is the in-repo `tech-logo-backstage.webp`, matching the Argo Workflows entry.
- New optional `overviewUrl` field on ecosystem entries, rendered in the item page body alongside the documentation link. Backstage uses it to link the portal overview page with screenshots and features.



## Related Issues

None.

## Checklist

- [x] Updated `sidebars.ts` if adding a new documentation page — n/a, no new page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
