### PR TITLE
docs: add production sizing guide with interactive calculator

### DIFF
--- a/docs/platform-engineer-guide/deployment-topology.mdx
+++ b/docs/platform-engineer-guide/deployment-topology.mdx
@@ -97,38 +97,8 @@ Use [cert-manager](https://cert-manager.io/) to automatically provision and rene
 
 ### Resource Requirements
 
-#### Control Plane
-
-| Component          | CPU Request | CPU Limit | Memory Request | Memory Limit |
-| ------------------ | ----------- | --------- | -------------- | ------------ |
-| Backstage          | 200m        | 2000m     | 256Mi          | 2Gi          |
-| OpenChoreo API     | 200m        | 1000m     | 256Mi          | 1Gi          |
-| Controller Manager | 200m        | 1000m     | 256Mi          | 1Gi          |
-| Cluster Gateway    | 100m        | 500m      | 64Mi           | 256Mi        |
-
-#### Data Plane
-
-| Component           | CPU Request | CPU Limit | Memory Request | Memory Limit |
-| ------------------- | ----------- | --------- | -------------- | ------------ |
-| KGateway Controller | 100m        | 200m      | 128Mi          | 256Mi        |
-| Cluster Agent       | 50m         | 100m      | 128Mi          | 256Mi        |
-
-#### Workflow Plane (Optional)
-
-| Component                 | CPU Request | CPU Limit | Memory Request | Memory Limit |
-| ------------------------- | ----------- | --------- | -------------- | ------------ |
-| Argo Workflows Controller | 25m         | 50m       | 32Mi           | 64Mi         |
-| Cluster Agent             | 50m         | 100m      | 128Mi          | 256Mi        |
-
-#### Observability Plane (Optional)
-
-| Component            | CPU Request | CPU Limit | Memory Request | Memory Limit |
-| -------------------- | ----------- | --------- | -------------- | ------------ |
-| Observer             | 100m        | 200m      | 128Mi          | 200Mi        |
-| Cluster Agent        | 50m         | 100m      | 128Mi          | 256Mi        |
-| SRE Agent (optional) | 100m        | 250m      | 1024Mi         | 1536Mi       |
-
-For resource requirements of the observability modules, please refer to the [observability modules documentation](https://github.com/openchoreo/community-modules).
+Per-plane CPU and memory sizing, what drives each plane's footprint, and an interactive
+estimator are covered in [Production Sizing](./production-sizing.mdx).
 
 ### Storage Requirements
 

--- a/docs/platform-engineer-guide/production-sizing.mdx
+++ b/docs/platform-engineer-guide/production-sizing.mdx
@@ -1,0 +1,216 @@
+---
+title: Production Sizing
+description: How much CPU and memory each OpenChoreo plane needs, what drives its size, and how to run it highly available.
+sidebar_position: 2
+---
+
+import SizingCalculator from "@site/src/components/SizingCalculator";
+
+# Production Sizing
+
+This guide covers what each plane runs, what drives its size, and how to make it highly
+available. The [sizing calculator](#estimate-your-footprint) at the end provides a rough
+estimate for your own installation. The identity provider, the secrets or key vault, and
+the managed PostgreSQL are outside its scope.
+
+## Control Plane
+
+The control plane carries no workloads of its own, so it stays small: memory is modest and
+grows only gently with what you deploy, CPU is low at rest, and a single small node pool is
+enough to run it.
+
+### Components
+
+| Component                    | Replicas | Notes                                                                                                   |
+| ---------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| API server                   | 2+       | stateless, load balanced                                                                                |
+| Controller manager           | 2+       | leader elected, only the leader reconciles; run 2+ for failover                                         |
+| Developer portal (Backstage) | 2+       | requires an externally hosted PostgreSQL                                                                |
+| Cluster gateway              | 1        | single replica by design; holds every plane's connection in memory, so the install keeps it to one      |
+| Event forwarder              | 1        | pushes catalog deltas to the portal; a periodic full sync is the backstop, so one replica is sufficient |
+
+### Sizing Rule
+
+**Size controller memory to the number of deployments, API CPU to the number of
+components, and run enough reconcile workers for your scale.**
+
+The controller manager applies rendered releases to the data plane, so it is I/O-bound
+rather than CPU- or memory-heavy: memory tracks object count and the 1Gi default is
+sufficient, and CPU stays low at rest.
+
+API CPU tracks onboarding bursts rather than install size: it rises while components are
+created and synced, roughly half a CPU per thousand components, and falls back at rest.
+
+Reconcile throughput is set by the controller's worker count; raise it if reconciles queue
+up as the install grows.
+
+## Data Plane
+
+Your workload pods run here, so this is the plane you scale the most, and it is dominated
+by the pods themselves.
+
+### Components
+
+| Component          | Replicas   | Notes                                                                                         |
+| ------------------ | ---------- | --------------------------------------------------------------------------------------------- |
+| Cluster agent      | 2+         | dials the control-plane gateway, which load balances across them                              |
+| Gateway controller | 2+         | leader elected; ships with the API gateway module you install                                 |
+| Gateway proxy      | 2+         | data-path load balancing; which proxy depends on the gateway module                           |
+| Log collector      | 1 per node | DaemonSet from the logs module; provider-backed modules use the provider's node agent instead |
+
+The OpenChoreo overhead here is small and mostly flat. The one piece that grows with the
+cluster is the log collector DaemonSet, which scales with node count and with log volume.
+Almost all the rest of the capacity is your own pods.
+
+The gateway grows too, but with **exposed routes**, not node or pod count. Each
+externally exposed endpoint programs an HTTPRoute, and gateway memory rises roughly
+linearly with route count: a few thousand exposed endpoints adds a few hundred MiB of
+gateway memory per replica, plus around one CPU under heavy route churn. A workload with
+no exposed endpoint adds no gateway cost.
+
+### Sizing Rule
+
+**Size to reserved requests: sum the per-pod CPU and memory requests across your pods, add
+a fixed per-node budget for the collectors, and let the node pool autoscale.**
+
+This capacity is your own workloads, not an OpenChoreo cost. Pod count is roughly
+components times environments times replicas, an upper bound since not everything runs in
+every environment.
+
+Requests bind before usage does: nodes fill up while actual CPU usage is around half, so
+the most effective optimization is right-sizing the per-pod request. Every node also
+carries a small fixed overhead for the log collector and the standard system agents.
+
+## Workflow Plane
+
+The workflow plane is active only while builds run. You provision it for your average
+build concurrency and cap it at a ceiling you choose, not by predicting how long any build
+takes.
+
+### Components
+
+| Component           | Replicas   | Notes                                                                           |
+| ------------------- | ---------- | ------------------------------------------------------------------------------- |
+| Workflow controller | 2+         | ships with 1 replica and leader election off; enable leader election to run 2   |
+| Cluster agent       | 2+         | connects to the control plane                                                   |
+| Log collector       | 1 per node | same per-node DaemonSet as the data plane                                       |
+| Image registry      | HA         | use a production-grade registry, in-cluster or managed; run it HA either way    |
+| Build pods          | per build  | short-lived, the dominant cost, each with its own CPU, memory, and scratch disk |
+
+### Sizing Rule
+
+**Provision for the average number of concurrent builds, and let node autoscaling absorb
+bursts up to a ceiling you choose. The ceiling becomes your node-pool maximum and the Argo
+parallelism cap.**
+
+The cap bounds how many build pods can exist at once. Build pods are short-lived and
+bursty, so node autoscaling adds nodes when builds arrive and drains them when idle, and
+cost tracks the average concurrency.
+
+Per-build cost depends on the build itself: language, toolchain, dependency graph, image
+size, and builder type all affect CPU, memory, and scratch disk. Measure a representative
+build of your own and size from that.
+
+The controller stays negligible no matter how many builds run; the cost is the build pods.
+Set the ceiling high enough that queueing stays acceptable.
+
+Build logs go to the observability plane, so factor that log volume into observability
+sizing if your build volume is high.
+
+## Observability Plane
+
+This is the heaviest plane to size, though the cost is almost entirely in the storage
+backends, not in OpenChoreo itself.
+
+### Sizing Depends on the Installed Modules
+
+The plane's footprint is driven by which
+[observability modules](https://openchoreo.dev/ecosystem/?group=module&category=Observability)
+you enable, so size it to the ones you run. Each signal has its own module, backend, and
+sizing driver: **logs** (log rate), **metrics** (cardinality), and **traces** (span rate).
+Size for all three:
+
+- **Self-hosted** (OpenSearch, Prometheus, OpenObserve): the
+  backend dominates. Size it to your telemetry volume using its own capacity-planning
+  guide; the calculator's figure is an example baseline, not a target.
+- **Provider-backed** (CloudWatch, Cloud Logging, Azure Monitor, X-Ray): the plane is only
+  the query layer, an adapter plus the API. Telemetry ships to the managed service, so
+  there is no in-cluster datastore to size. Run the query layer HA; only developers query
+  it, so its load stays light.
+
+### Core OpenChoreo Components
+
+These are the OpenChoreo-owned components of the plane. All of them are lightweight: a few
+millicores and tens of MiB each.
+
+| Component                       | Replicas | Notes                                                                                                                            |
+| ------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Observer (query API and alerts) | 2+ (HA)  | HA needs `alertStoreBackend: postgresql`; the SQLite default runs a single replica. Scale to API load, usually light (devs only) |
+| Controller manager              | 2+       | leader elected; HA requires `--leader-elect=true`, which the chart omits by default                                              |
+| Cluster agent                   | 2+       | stateless, planeID-scoped, freely scalable                                                                                       |
+| Events collector                | 1        | single replica (`k8seventsreceiver`); scale it up, not out. Present in any default install (events-otel-collector module)        |
+
+### Module-Specific Backends and Collectors
+
+Everything with a significant footprint here is module-specific, not part of the core
+plane chart. Each module pairs a light OpenChoreo-authored collector or adapter with a
+backend, and the backend dominates: the self-hosted datastore accounts for most of the
+plane's footprint. Run it HA per its own guide, with persistent disks and retention
+limits.
+
+The collectors and adapters are standard components, packaged and configured by whichever
+module you install:
+
+- **Logs**: Fluent Bit or a cloud agent.
+- **Metrics**: Prometheus or its agent, or a cloud metric agent.
+- **Traces**: an OpenTelemetry Collector.
+
+They are lightweight and easy to run. Notable behaviors:
+
+- **The log collector** runs as a DaemonSet, one pod per data-plane and workflow-plane
+  node, and scales with node count and log volume.
+- **The metrics agent** needs memory scaled to the pod count it watches; the shipped
+  default runs out of memory on large clusters.
+- **The tracing collector** can run HA, but scaling past one replica requires a
+  load-balancing tier in front of a tail-sampling tier, not a simple replica increase.
+
+Provider-backed modules install only a light adapter plus a collector that pushes to the
+managed backend, reducing the backend footprint to a few small pods.
+
+### Sizing Rule
+
+**The OpenChoreo components are lightweight, so size the installed backend to your
+telemetry volume using its upstream guide.** The per-node log collector is already counted
+in the data and workflow plane budgets.
+
+## Estimate Your Footprint
+
+The calculator turns your workload into a rough estimate of the CPU and memory each plane
+needs, and the split between the platform and your own workloads. It is a starting point,
+not a target.
+
+<SizingCalculator />
+
+<details>
+<summary>Assumptions</summary>
+
+- **Multi-cluster.** Each plane runs in its own cluster; cluster overhead and cross-cluster
+  traffic are not counted.
+- **One data plane**, carrying every environment. Splitting across planes adds a set of
+  agents and a gateway per plane, and each plane packs its nodes separately.
+- **Every component in every environment**, so deployments are components times
+  environments. That makes it an upper bound: anything not yet promoted produces fewer
+  deployments.
+- **Observability is the least precise figure.** It assumes a tuned telemetry pipeline. The
+  OpenSearch figures come from a measured install, the OpenObserve figures from the
+  vendor's capacity planner, and the provider-backed stacks from their modules' chart
+  requests, which are flat because only developer queries reach them. Size the backend you
+  actually install with its provider's capacity-planning guide.
+- **Not modeled:** gateway route growth and the roughly 12 GiB of scratch disk each build
+  pod needs.
+- **Node counts assume about 80 pods per node.** Your node size changes the node count,
+  not the CPU and memory totals.
+- **Workflow figures are the steady state** at your average concurrency. Provision the
+  node-pool maximum for your build ceiling.
+
+</details>

--- a/plugins/docusaurus-plugin-markdown-export/mdxProcessor.js
+++ b/plugins/docusaurus-plugin-markdown-export/mdxProcessor.js
@@ -128,6 +128,7 @@ function processInstallComponents(content) {
   result = result.replace(/<SetupOption\b[^>]*\binteractive\b[^>]*>[\s\S]*?<\/SetupOption>/g, '');
   result = result.replace(/<AgentCallout\b[^>]*>[\s\S]*?<\/AgentCallout>/g, '');
   result = result.replace(/<AgentSetupBuilder\b[^>]*\/>/g, '');
+  result = result.replace(/<SizingCalculator\b[^>]*\/>/g, '');
   // Unwrap the picker containers, keeping the remaining panels' markdown so the
   // exported guide reads as plain markdown.
   result = result.replace(/<\/?SetupSwitch>/g, '');

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -84,6 +84,7 @@ const sidebars: SidebarsConfig = {
             "Install, configure, and connect your OpenChoreo infrastructure",
           items: [
             "platform-engineer-guide/deployment-topology",
+            "platform-engineer-guide/production-sizing",
             "platform-engineer-guide/multi-cluster-connectivity",
             "platform-engineer-guide/air-gapped-installation",
             "platform-engineer-guide/external-ca-tls-setup",

--- a/src/components/SizingCalculator/index.tsx
+++ b/src/components/SizingCalculator/index.tsx
@@ -1,0 +1,757 @@
+import React, { useEffect, useRef, useState } from "react";
+import styles from "./styles.module.css";
+
+const PODS_PER_NODE = 80; // 100 per node at about 80% utilisation
+
+// fluent-bit collectors scale with log volume (pods x log rate), not a flat per-node amount.
+// Model: nodes x idle-floor + totPods x rate x per-line. Constants from the bench10 ramp
+// regression (~0.04 MiB & ~0.03m per line/s/pod); idle floor from op-baseline (~6 MiB/node).
+const LOG_RATE = 3; // log lines/s/pod, realistic average
+const FB_NODE_MEM = 0.006;
+const FB_NODE_CPU = 0.0025;
+const FB_MEM_PER_LINE = 0.00004;
+const FB_CPU_PER_LINE = 0.00003;
+const METRICS_MEM_PER_POD = 0.0025; // GiB per pod, remote-write metrics agent
+const WP_BASE_CPU = 0.3;
+const WP_BASE_MEM = 0.5;
+
+// control-plane per-component sizing (bench10 measured @ 3000 components, with headroom)
+const CP_PORTAL_MEM = 0.4; // Backstage per replica (request 256Mi, measured ~277 MiB)
+const CP_API_MEM = 0.1;
+const CP_GW_MEM = 0.1;
+const CP_BASE_CPU = 1.0; // controllers + gateway + portal + api at rest
+// event-forwarder: linear in catalog size, 1 replica. Fitted across both bench10 ramps
+// (stock 17.9 + 0.0252/comp, 10-worker 18.8 + 0.0306/comp).
+const CP_EF_BASE_MEM = 18 / 1024;
+const CP_EF_MEM_PER_COMP = 0.03 / 1024;
+
+// Observability stacks, assembled from the community observability modules.
+// Self-hosted stacks carry an in-cluster datastore; provider-backed ones install only an
+// adapter plus a collector that pushes to the managed service, so the in-cluster footprint
+// collapses and the cost moves to the vendor bill.
+//
+// Provenance: the OpenSearch row is measured (bench10: 3 master + 2 data, 4 GiB heap,
+// 100 GiB PVC); the OpenObserve row is derived from the vendor's capacity planner; the
+// provider-backed rows are sized from their modules' chart requests (see the AWS row
+// comment, which applies to all three).
+type Stack = {
+  id: string;
+  label: string;
+  modules: string;
+  baseLabel: string;
+  baseMem: number;
+  baseCpu: number;
+  memPerKPod: number;
+  cpuPerKPod: number;
+  selfHosted: boolean;
+};
+
+const STACKS: Stack[] = [
+  {
+    id: "opensearch",
+    label: "OpenSearch",
+    modules: "OpenSearch logs and tracing, Prometheus metrics",
+    baseLabel: "OpenSearch and Prometheus",
+    baseMem: 19, // measured idle floor
+    baseCpu: 3, // within the measured idle range
+    memPerKPod: 0.25, // derived from stress-rate measurement, rescaled to 3 lines/s/pod
+    cpuPerKPod: 0.2, // judgment; bench CPU showed no clean growth under backpressure
+    selfHosted: true,
+  },
+  {
+    id: "openobserve",
+    label: "OpenObserve",
+    modules: "OpenObserve logs and tracing, Prometheus metrics",
+    baseLabel: "OpenObserve and Prometheus",
+    // Growth from "Capacity planning for OpenObserve 1.0" (vendor sheet, 2025-12-16),
+    // HA/distributed, light-analytics profile (queriers = 3x ingesters): 32 provisioned
+    // variable cores per TB/day (ingest at 9 MB/s/core with 4x spike headroom), memory
+    // at the planner's 8 GB/core shape, mapped through the model's 3 lines/s/pod at
+    // 200 B (1000 pods ~ 52 GB/day). The floor is NOT from the sheet: the planner
+    // targets TB/day and its fixed-service shape (2-core compactor, 8 GB/core nodes)
+    // does not describe small installs, so the floor here is the fixed services scaled
+    // to sub-100 GB/day plus Prometheus (2 x 500m/2Gi) for metrics. Metadata RDS is
+    // external, like the managed PostgreSQL excluded elsewhere in this model.
+    baseMem: 10,
+    baseCpu: 3,
+    memPerKPod: 13,
+    cpuPerKPod: 1.6,
+    selfHosted: true,
+  },
+  {
+    id: "aws",
+    label: "AWS",
+    modules: "CloudWatch logs and metrics, X-Ray tracing",
+    baseLabel: "CloudWatch and X-Ray adapters",
+    // Applies to all three provider-backed rows (their module charts are near-identical):
+    // chart requests at HA (x2) for the three query adapters (~50m/128Mi each) plus the
+    // tracing OTel collector (~100m/200Mi), plus the plane chart's core (observer,
+    // controller, agent: ~0.5 vCPU / 1 GiB of requests at x2). Growth is zero because the
+    // query path is load-insensitive (bench: warm query latency flat across the whole
+    // ramp) and telemetry shipping is the cloud provider's node agent, billed off-cluster.
+    baseMem: 2,
+    baseCpu: 1,
+    memPerKPod: 0,
+    cpuPerKPod: 0,
+    selfHosted: false,
+  },
+  {
+    id: "azure",
+    label: "Azure",
+    modules: "Log Analytics, Azure Monitor, Application Insights",
+    baseLabel: "Azure Monitor adapters",
+    // Same basis as the AWS row above.
+    baseMem: 2,
+    baseCpu: 1,
+    memPerKPod: 0,
+    cpuPerKPod: 0,
+    selfHosted: false,
+  },
+  {
+    id: "gcp",
+    label: "Google Cloud",
+    modules: "Cloud Logging, Cloud Monitoring, Cloud Trace",
+    baseLabel: "Google Cloud adapters",
+    // Same basis as the AWS row above.
+    baseMem: 2,
+    baseCpu: 1,
+    memPerKPod: 0,
+    cpuPerKPod: 0,
+    selfHosted: false,
+  },
+];
+
+const nf = (n: number) =>
+  n.toLocaleString(undefined, { maximumFractionDigits: 1 });
+const num = (v: string, d: number, mn: number) => Math.max(mn, Number(v) || d);
+const pct = (v: number, t: number) => (t > 0 ? Math.round((100 * v) / t) : 0);
+const shown = (v: number) => v >= 0.05;
+
+type Part = { label: string; mem: number; cpu: number };
+const fmtPart = (pt: Part) => {
+  const a: string[] = [];
+  if (shown(pt.cpu)) a.push(`${nf(pt.cpu)} vCPU`);
+  if (shown(pt.mem)) a.push(`${nf(pt.mem)} GiB`);
+  return a.join(", ") || "-";
+};
+
+const MAX_ENVS = 6;
+// components span two orders of magnitude, so the slider is log-scaled and snapped to
+// round numbers; a linear track would bury the 25-200 range most installs sit in.
+const COMP_MIN = 25;
+const COMP_MAX = 1000;
+const snapComp = (v: number) =>
+  v < 100
+    ? Math.round(v / 5) * 5
+    : v < 500
+      ? Math.round(v / 10) * 10
+      : Math.round(v / 25) * 25;
+const compFromPos = (pos: number) =>
+  snapComp(COMP_MIN * Math.pow(COMP_MAX / COMP_MIN, pos / 100));
+const posFromComp = (c: number) =>
+  (100 * Math.log(c / COMP_MIN)) / Math.log(COMP_MAX / COMP_MIN);
+
+function Slider({
+  label,
+  value,
+  display,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  display?: string;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className={styles.slider}>
+      <div className={styles.sliderTop}>
+        <label>{label}</label>
+        <span className={styles.sliderVal}>{display ?? value}</span>
+      </div>
+      <input
+        type="range"
+        aria-label={label}
+        min={min}
+        max={max}
+        step={step ?? 1}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </div>
+  );
+}
+
+function NumRow({
+  label,
+  value,
+  onChange,
+  min,
+  step,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  min: number;
+  step?: number;
+}) {
+  return (
+    <label className={styles.numRow}>
+      <span>{label}</span>
+      <input
+        type="number"
+        min={min}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </label>
+  );
+}
+
+function usePopover() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node))
+        setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false);
+    document.addEventListener("mousedown", onDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return { open, toggle: () => setOpen((v) => !v), ref };
+}
+
+function PopPanel({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={styles.popPanel} role="dialog" aria-label={title}>
+      <div className={styles.popTitle}>{title}</div>
+      {children}
+    </div>
+  );
+}
+
+function Advanced({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  const pop = usePopover();
+  return (
+    <div className={styles.pop} ref={pop.ref}>
+      <button
+        type="button"
+        className={styles.popBtn}
+        aria-expanded={pop.open}
+        onClick={pop.toggle}
+      >
+        {title}
+      </button>
+      {pop.open && <PopPanel title={title}>{children}</PopPanel>}
+    </div>
+  );
+}
+
+function Breakdown({ name, parts }: { name: string; parts: Part[] }) {
+  const pop = usePopover();
+  return (
+    <div className={styles.pop} ref={pop.ref}>
+      <button
+        type="button"
+        className={styles.pexp}
+        aria-expanded={pop.open}
+        aria-label={`Break down ${name}`}
+        onClick={pop.toggle}
+      >
+        <svg
+          className={`${styles.chev} ${pop.open ? styles.chevOpen : ""}`}
+          viewBox="0 0 16 16"
+          width="12"
+          height="12"
+          aria-hidden="true"
+        >
+          <path
+            d="M6 4l4 4-4 4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.6"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      {pop.open && (
+        <PopPanel title={name}>
+          {parts.map((pt) => (
+            <div key={pt.label} className={styles.keyRow}>
+              <span>{pt.label}</span>
+              <span>{fmtPart(pt)}</span>
+            </div>
+          ))}
+        </PopPanel>
+      )}
+    </div>
+  );
+}
+
+type Plane = {
+  name: string;
+  on: boolean;
+  locked?: boolean;
+  onToggle?: (v: boolean) => void;
+  cpuP: number;
+  memP: number;
+  cpuW: number;
+  memW: number;
+  parts: Part[];
+  mid: React.ReactNode;
+};
+
+function PlaneRow({
+  plane,
+  hot,
+  onHover,
+}: {
+  plane: Plane;
+  hot: boolean;
+  onHover: () => void;
+}) {
+  const { name, on, locked, onToggle, mid } = plane;
+  const cpu = plane.cpuP + plane.cpuW;
+  const mem = plane.memP + plane.memW;
+  const parts = plane.parts.filter((pt) => shown(pt.mem) || shown(pt.cpu));
+  return (
+    <div
+      className={`${styles.prow} ${on ? "" : styles.rowOff} ${hot ? styles.rowHot : ""}`}
+      onMouseEnter={onHover}
+    >
+      <label
+        className={`${styles.check} ${locked ? styles.checkLocked : ""}`}
+        title={locked ? "Always installed" : undefined}
+      >
+        <input
+          type="checkbox"
+          checked={on}
+          disabled={locked}
+          onChange={(e) => onToggle?.(e.target.checked)}
+        />
+        {name}
+      </label>
+      <div className={styles.pmid}>
+        {on ? mid : <span className={styles.pnote}>not installed</span>}
+      </div>
+      <span className={styles.pnum}>
+        {on ? (
+          <>
+            {nf(cpu)} <span className={styles.unit}>vCPU</span>
+          </>
+        ) : (
+          "-"
+        )}
+      </span>
+      <span className={styles.pnum}>
+        {on ? (
+          <>
+            {nf(mem)} <span className={styles.unit}>GiB</span>
+          </>
+        ) : (
+          "-"
+        )}
+      </span>
+      {on && parts.length ? <Breakdown name={name} parts={parts} /> : <span />}
+    </div>
+  );
+}
+
+export default function SizingCalculator() {
+  const [comp, setComp] = useState(50);
+  const [env, setEnv] = useState(2);
+  const [avgBuilds, setAvgBuilds] = useState("2");
+  const [maxBuilds, setMaxBuilds] = useState("5");
+  const [podCpuIn, setPodCpu] = useState("0.1");
+  const [podMemIn, setPodMem] = useState("0.25");
+  const [replicasIn, setReplicas] = useState("2");
+  const [buildCpuIn, setBuildCpu] = useState("1");
+  const [buildMemIn, setBuildMem] = useState("2");
+  const [wpOn, setWpOn] = useState(true);
+  const [opOn, setOpOn] = useState(true);
+  const [stackId, setStackId] = useState(STACKS[0].id);
+  const [hoverPlane, setHoverPlane] = useState<number | null>(null);
+
+  // clearing the hover keeps the footer from narrating a plane that was just removed
+  const togglePlane = (set: (v: boolean) => void) => (v: boolean) => {
+    setHoverPlane(null);
+    set(v);
+  };
+
+  const mc = Math.max(0, Number(maxBuilds) || 0);
+  const avg = Math.min(Math.max(0, Number(avgBuilds) || 0), mc);
+  const podCpu = num(podCpuIn, 0.1, 0.01);
+  const podMem = num(podMemIn, 0.25, 0.01);
+  const replicas = num(replicasIn, 2, 1);
+  const buildCpu = num(buildCpuIn, 1, 0.1);
+  const buildMem = num(buildMemIn, 2, 0.1);
+
+  // One data plane hosting every environment; deployments are components times environments.
+  const totDep = comp * env;
+  const totPods = totDep * replicas;
+  const totNodes = Math.ceil(totPods / PODS_PER_NODE);
+
+  const workCpu = totPods * podCpu;
+  const workMem = totPods * podMem;
+  const dpAgentCpu = 0.3; // cluster-agent + gateway at rest
+  const dpAgentMem = 0.8;
+  const dpCollMem =
+    totNodes * FB_NODE_MEM + totPods * LOG_RATE * FB_MEM_PER_LINE;
+  const dpCollCpu =
+    totNodes * FB_NODE_CPU + totPods * LOG_RATE * FB_CPU_PER_LINE;
+  const dpMetricMem = METRICS_MEM_PER_POD * totPods;
+
+  // Controllers x2 provisioned at leader size (standby must handle failover). CPU rises
+  // with components as openchoreo-api catalog-syncs (bench10: ~0.5 core/replica under sync).
+  const ctrlMem = (2 * (40 + 0.05 * totDep)) / 1024;
+  const efMem = CP_EF_BASE_MEM + CP_EF_MEM_PER_COMP * comp;
+  const cpMem =
+    ctrlMem + 2 * CP_API_MEM + 2 * CP_PORTAL_MEM + CP_GW_MEM + efMem;
+  const cpCpu = CP_BASE_CPU + 0.5 * (comp / 1000);
+
+  // steady-state sizes to average concurrent builds; node autoscaling absorbs bursts
+  const wpCpu = WP_BASE_CPU + avg * buildCpu;
+  const wpMem = WP_BASE_MEM + avg * buildMem;
+
+  // Backend floor + gentle growth with telemetry (proxied by total pods). For self-hosted
+  // stacks the floor is the datastore's heap; for provider-backed ones it is just adapters.
+  const stack = STACKS.find((s) => s.id === stackId) ?? STACKS[0];
+  const opMem = stack.baseMem + stack.memPerKPod * (totPods / 1000);
+  const opCpu = stack.baseCpu + stack.cpuPerKPod * (totPods / 1000);
+
+  const planes: Plane[] = [
+    {
+      name: "Control plane",
+      on: true,
+      locked: true,
+      cpuP: cpCpu,
+      memP: cpMem,
+      cpuW: 0,
+      memW: 0,
+      parts: [
+        { label: "Developer portal", mem: 2 * CP_PORTAL_MEM, cpu: 0 },
+        { label: "Controllers", mem: ctrlMem, cpu: 0 },
+        { label: "API and gateway", mem: 2 * CP_API_MEM + CP_GW_MEM, cpu: 0 },
+        { label: "Catalog event forwarder", mem: efMem, cpu: 0 },
+        { label: "Services at rest", mem: 0, cpu: CP_BASE_CPU },
+        { label: "API catalog sync", mem: 0, cpu: 0.5 * (comp / 1000) },
+      ],
+      mid: (
+        <span className={styles.pnote}>
+          {nf(totDep)} deployments, near-fixed cost
+        </span>
+      ),
+    },
+    {
+      name: "Data plane",
+      on: true,
+      locked: true,
+      cpuP: dpAgentCpu + dpCollCpu,
+      memP: dpAgentMem + dpCollMem + dpMetricMem,
+      cpuW: workCpu,
+      memW: workMem,
+      parts: [
+        { label: "Workload pods", mem: workMem, cpu: workCpu },
+        {
+          label: "Cluster agents and gateway",
+          mem: dpAgentMem,
+          cpu: dpAgentCpu,
+        },
+        { label: "Log collectors", mem: dpCollMem, cpu: dpCollCpu },
+        { label: "Metrics agent", mem: dpMetricMem, cpu: 0 },
+      ],
+      mid: (
+        <span className={styles.pnote}>
+          {nf(totPods)} pods, about {totNodes} nodes
+        </span>
+      ),
+    },
+    {
+      name: "Workflow plane",
+      on: wpOn,
+      onToggle: togglePlane(setWpOn),
+      cpuP: WP_BASE_CPU,
+      memP: WP_BASE_MEM,
+      cpuW: avg * buildCpu,
+      memW: avg * buildMem,
+      parts: [
+        { label: "Build pods", mem: avg * buildMem, cpu: avg * buildCpu },
+        { label: "Controller and agent", mem: WP_BASE_MEM, cpu: WP_BASE_CPU },
+      ],
+      mid: (
+        <div className={styles.rowFields}>
+          <label className={styles.rowField}>
+            Max builds
+            <input
+              type="number"
+              min={0}
+              max={50}
+              value={maxBuilds}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === "") {
+                  setMaxBuilds("");
+                  return;
+                }
+                const m = Math.min(50, Math.max(0, Number(v) || 0));
+                setMaxBuilds(String(m));
+                if ((Number(avgBuilds) || 0) > m) setAvgBuilds(String(m));
+              }}
+            />
+          </label>
+          <label className={styles.rowField}>
+            Average
+            <input
+              type="number"
+              min={0}
+              max={mc}
+              value={avgBuilds}
+              onChange={(e) => {
+                const v = e.target.value;
+                if (v === "") {
+                  setAvgBuilds("");
+                  return;
+                }
+                setAvgBuilds(String(Math.min(Math.max(0, Number(v) || 0), mc)));
+              }}
+            />
+          </label>
+        </div>
+      ),
+    },
+    {
+      name: "Observability plane",
+      on: opOn,
+      onToggle: togglePlane(setOpOn),
+      cpuP: opCpu,
+      memP: opMem,
+      cpuW: 0,
+      memW: 0,
+      parts: [
+        { label: stack.baseLabel, mem: stack.baseMem, cpu: stack.baseCpu },
+        {
+          label: "Telemetry growth",
+          mem: stack.memPerKPod * (totPods / 1000),
+          cpu: stack.cpuPerKPod * (totPods / 1000),
+        },
+      ],
+      mid: (
+        <select
+          className={styles.select}
+          value={stackId}
+          aria-label="Observability stack"
+          onChange={(e) => setStackId(e.target.value)}
+        >
+          {STACKS.map((st) => (
+            <option key={st.id} value={st.id}>
+              {st.label} ({st.selfHosted ? "self-hosted" : "provider-backed"})
+            </option>
+          ))}
+        </select>
+      ),
+    },
+  ];
+
+  const active = (get: (p: Plane) => number) =>
+    planes.reduce((sum, p) => sum + (p.on ? get(p) : 0), 0);
+  const totCpu = active((p) => p.cpuP + p.cpuW);
+  const totMem = active((p) => p.memP + p.memW);
+  const workloadCpu = active((p) => p.cpuW);
+  const workloadMem = active((p) => p.memW);
+
+  const bar = (
+    getP: (p: Plane) => number,
+    getW: (p: Plane) => number,
+    tot: number,
+  ) => {
+    const segs = (get: (p: Plane) => number, cls: string) =>
+      planes.map((p, i) =>
+        p.on && get(p) > 0 ? (
+          <div
+            key={`${cls}${i}`}
+            className={`${styles.seg} ${cls} ${hoverPlane === i ? styles.segOn : ""}`}
+            style={{ width: `${(100 * get(p)) / tot}%` }}
+            onMouseEnter={() => setHoverPlane(i)}
+          />
+        ) : null,
+      );
+    return (
+      <div
+        className={`${styles.bar} ${hoverPlane !== null ? styles.barDim : ""}`}
+        onMouseLeave={() => setHoverPlane(null)}
+      >
+        {segs(getP, styles.segSys)}
+        {segs(getW, styles.segWork)}
+      </div>
+    );
+  };
+
+  const hovered = hoverPlane !== null ? planes[hoverPlane] : null;
+
+  return (
+    <div className={styles.calc}>
+      <div className={styles.panel}>
+        <div className={styles.controls}>
+          <div className={styles.ctrlGrid}>
+            <Slider
+              label="Components"
+              value={posFromComp(comp)}
+              display={nf(comp)}
+              min={0}
+              max={100}
+              step={0.1}
+              onChange={(pos) => setComp(compFromPos(pos))}
+            />
+            <Slider
+              label="Environments"
+              value={env}
+              min={1}
+              max={MAX_ENVS}
+              onChange={setEnv}
+            />
+          </div>
+
+          <div className={styles.ctrlFoot}>
+            <span>
+              {nf(totDep)} deployments, {nf(totPods)} pods, about {totNodes}{" "}
+              nodes
+            </span>
+            <Advanced title="Pod profiles">
+              <div className={styles.popSection}>Workload pod</div>
+              <NumRow
+                label="CPU (vCPU)"
+                value={podCpuIn}
+                min={0.01}
+                step={0.05}
+                onChange={setPodCpu}
+              />
+              <NumRow
+                label="Memory (GiB)"
+                value={podMemIn}
+                min={0.01}
+                step={0.05}
+                onChange={setPodMem}
+              />
+              <NumRow
+                label="Replicas per deployment"
+                value={replicasIn}
+                min={1}
+                onChange={setReplicas}
+              />
+              <div className={styles.popSection}>Build pod</div>
+              <NumRow
+                label="CPU (vCPU)"
+                value={buildCpuIn}
+                min={0.1}
+                step={0.5}
+                onChange={setBuildCpu}
+              />
+              <NumRow
+                label="Memory (GiB)"
+                value={buildMemIn}
+                min={0.1}
+                step={0.5}
+                onChange={setBuildMem}
+              />
+            </Advanced>
+          </div>
+        </div>
+
+        <div className={styles.table} onMouseLeave={() => setHoverPlane(null)}>
+          <div className={styles.thead}>
+            <span>Plane</span>
+            <span aria-hidden="true" />
+            <span>CPU</span>
+            <span>Memory</span>
+            <span aria-hidden="true" />
+          </div>
+          {planes.map((p, i) => (
+            <PlaneRow
+              key={p.name}
+              plane={p}
+              hot={hoverPlane === i}
+              onHover={() => setHoverPlane(p.on ? i : null)}
+            />
+          ))}
+        </div>
+
+        <div className={styles.share} onMouseLeave={() => setHoverPlane(null)}>
+          <p className={styles.summary}>
+            You will need roughly <b>{nf(totCpu)} vCPU</b> and{" "}
+            <b>{nf(totMem)} GiB</b> in total, with about <b>{totNodes}</b>{" "}
+            {totNodes === 1 ? "node" : "nodes"} carrying the data plane.
+          </p>
+          <div className={styles.shareGrid}>
+            <div>
+              <div className={styles.shareTop}>
+                <span className={styles.shareLabel}>CPU</span>
+                <span className={styles.shareVal}>
+                  {nf(totCpu)} <span>vCPU</span>
+                </span>
+              </div>
+              {bar(
+                (p) => p.cpuP,
+                (p) => p.cpuW,
+                totCpu,
+              )}
+            </div>
+            <div>
+              <div className={styles.shareTop}>
+                <span className={styles.shareLabel}>Memory</span>
+                <span className={styles.shareVal}>
+                  {nf(totMem)} <span>GiB</span>
+                </span>
+              </div>
+              {bar(
+                (p) => p.memP,
+                (p) => p.memW,
+                totMem,
+              )}
+            </div>
+          </div>
+          <div className={styles.shareFoot}>
+            <span className={styles.legend}>
+              <span className={`${styles.dot} ${styles.segWork}`} />
+              your workloads
+              <span className={`${styles.dot} ${styles.segSys}`} />
+              platform
+            </span>
+            <span className={styles.shareNote}>
+              {hovered
+                ? `${hovered.name}: ${pct(hovered.cpuP + hovered.cpuW, totCpu)}% of CPU, ${pct(hovered.memP + hovered.memW, totMem)}% of memory`
+                : `Your workloads: ${pct(workloadCpu, totCpu)}% of CPU, ${pct(workloadMem, totMem)}% of memory`}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SizingCalculator/styles.module.css
+++ b/src/components/SizingCalculator/styles.module.css
@@ -1,0 +1,537 @@
+/* Layout keys off the component's own width: it sits in a docs column whose size
+   depends on the sidebar and TOC, so viewport media queries are the wrong signal. */
+.calc {
+  --sc-tint: var(--ifm-color-emphasis-100);
+  --sc-line: var(--ifm-color-emphasis-200); /* structural dividers */
+  --sc-border: var(--ifm-color-emphasis-300); /* interactive control outlines */
+  --sc-track: var(--ifm-color-emphasis-200); /* inert bar and slider tracks */
+  --sc-accent: var(
+    --ifm-color-primary
+  ); /* your workloads, and every interactive state */
+  --sc-plat: var(--ifm-color-emphasis-600); /* platform */
+  --sc-surface: var(--ifm-background-surface-color); /* raised surfaces */
+  --sc-field: var(--ifm-background-color); /* input wells */
+  /* Sizes step down from the docs body size rather than replacing it, so the
+     component sits in the page rather than beside it. No fifth size. */
+  --sc-lg: 1.5rem;
+  --sc-md: 1rem;
+  --sc-sm: 0.875rem;
+  --sc-xs: 0.8125rem;
+  --sc-fg: var(--ifm-font-color-base);
+  --sc-fg2: var(--ifm-color-emphasis-700);
+  --sc-fg3: var(--ifm-color-emphasis-600);
+  container-type: inline-size;
+  margin: 1.5rem 0 2rem;
+}
+
+.panel {
+  border: 1px solid var(--sc-line);
+  border-radius: 14px;
+}
+/* No overflow:hidden on .panel — it clipped the popovers. The end bands carry
+   the matching inner radii instead. */
+.share {
+  border-radius: 0 0 13px 13px;
+}
+
+/* The track must stay clearly lighter than the platform segments, or a
+   platform-only plane is invisible against its own track. */
+.bar {
+  display: flex;
+  height: 14px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: var(--sc-track);
+}
+.seg {
+  min-width: 4px;
+  transition: opacity 0.12s;
+}
+.segSys {
+  background: var(--sc-plat);
+}
+.segWork {
+  background: var(--sc-accent);
+}
+/* Fade the rest right down so the highlighted segment is the only one left
+   reading against the track. */
+.barDim .seg {
+  opacity: 0.13;
+}
+.barDim .segOn {
+  opacity: 1;
+}
+
+/* ---------- controls ---------- */
+
+.controls {
+  padding: 18px 22px 16px;
+  border-bottom: 1px solid var(--sc-line);
+  border-radius: 13px 13px 0 0;
+  line-height: 1.45;
+}
+
+.ctrlGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 16px 32px;
+}
+
+.sliderTop {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 7px;
+}
+.sliderTop label {
+  color: var(--sc-fg2);
+}
+.sliderVal {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--sc-fg);
+}
+
+.slider input[type="range"] {
+  -webkit-appearance: none;
+  appearance: none;
+  display: block;
+  width: 100%;
+  height: 4px;
+  margin: 0;
+  border-radius: 3px;
+  background: var(--sc-track);
+  cursor: pointer;
+}
+.slider input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--sc-accent);
+  border: 2px solid var(--sc-surface);
+  box-shadow: 0 0 0 1px var(--sc-accent);
+}
+.slider input[type="range"]::-moz-range-thumb {
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--sc-accent);
+  border: 2px solid var(--sc-surface);
+  box-shadow: 0 0 0 1px var(--sc-accent);
+}
+.slider input[type="range"]:focus-visible {
+  outline: 2px solid var(--sc-accent);
+  outline-offset: 4px;
+}
+
+.check {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--sc-fg);
+}
+.check input {
+  flex: none;
+  accent-color: var(--sc-accent);
+  cursor: pointer;
+  margin: 0;
+  width: 13px;
+  height: 13px;
+}
+
+.ctrlFoot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 14px;
+  font-size: var(--sc-sm);
+  color: var(--sc-fg3);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ---------- advanced popover ---------- */
+
+.pop {
+  position: relative;
+  flex: none;
+}
+.popBtn {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 10px;
+  border: 1px solid var(--sc-border);
+  border-radius: 999px;
+  background: none;
+  font: inherit;
+  font-size: var(--sc-sm);
+  font-weight: 500;
+  color: var(--sc-fg2);
+  cursor: pointer;
+  transition:
+    border-color 0.12s,
+    color 0.12s,
+    background 0.12s;
+}
+.popBtn:hover,
+.popBtn[aria-expanded="true"] {
+  border-color: var(--sc-accent);
+  color: var(--sc-accent);
+}
+.popBtn:focus-visible {
+  outline: 2px solid var(--sc-accent);
+  outline-offset: 2px;
+}
+
+.popPanel {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  z-index: 5;
+  width: max(240px, 100%);
+  padding: 12px 14px 14px;
+  border: 1px solid var(--sc-border);
+  border-radius: 10px;
+  background: var(--sc-surface);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
+  text-align: left;
+}
+.popTitle {
+  margin-bottom: 8px;
+  font-size: var(--sc-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--sc-fg3);
+}
+.popSection {
+  margin: 10px 0 2px;
+  font-size: var(--sc-xs);
+  font-weight: 600;
+  color: var(--sc-fg2);
+}
+.popSection:first-of-type {
+  margin-top: 0;
+}
+
+.numRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 3px 0;
+  font-size: var(--sc-sm);
+  color: var(--sc-fg2);
+  cursor: pointer;
+}
+.numRow input {
+  width: 5rem;
+  padding: 3px 8px;
+  border: 1px solid var(--sc-border);
+  border-radius: 6px;
+  background: var(--sc-field);
+  color: var(--sc-fg);
+  font: inherit;
+  font-size: var(--sc-sm);
+  text-align: right;
+}
+.numRow input:focus {
+  outline: none;
+  border-color: var(--sc-accent);
+}
+
+/* ---------- table ---------- */
+
+.table {
+  padding: 6px 14px 10px;
+  line-height: 1.45;
+}
+
+/* Every row carries the highlight padding permanently, so hovering only changes
+   the background. Nothing in this grid may move on hover. */
+.thead,
+.prow {
+  display: grid;
+  grid-template-columns: minmax(9rem, auto) minmax(0, 1fr) 5.6rem 5.8rem 1.6rem;
+  align-items: center;
+  column-gap: 12px;
+  padding: 9px 8px;
+  border-radius: 8px;
+}
+
+.thead {
+  padding-top: 4px;
+  padding-bottom: 6px;
+  font-size: var(--sc-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--sc-fg3);
+}
+.thead span:nth-child(3),
+.thead span:nth-child(4) {
+  text-align: right;
+}
+
+.prow {
+  transition: background 0.12s;
+}
+.prow + .prow {
+  box-shadow: inset 0 1px 0 var(--sc-line);
+}
+.rowHot {
+  background: var(--sc-tint);
+}
+
+.pmid {
+  min-width: 0;
+}
+
+.rowFields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+}
+.rowField {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--sc-sm);
+  color: var(--sc-fg2);
+  cursor: pointer;
+}
+.rowField input {
+  width: 3.6rem;
+  padding: 3px 8px;
+  border: 1px solid var(--sc-border);
+  border-radius: 6px;
+  background: var(--sc-field);
+  color: var(--sc-fg);
+  font: inherit;
+  font-size: var(--sc-sm);
+  text-align: right;
+}
+.rowField input:focus {
+  outline: none;
+  border-color: var(--sc-accent);
+}
+
+.select {
+  max-width: 100%;
+  padding: 5px 10px;
+  border: 1px solid var(--sc-border);
+  border-radius: 6px;
+  background: var(--sc-field);
+  color: var(--sc-fg);
+  font: inherit;
+  font-size: var(--sc-sm);
+}
+.select:focus-visible {
+  outline: 2px solid var(--sc-accent);
+  outline-offset: 2px;
+}
+
+.checkLocked,
+.checkLocked input {
+  cursor: default;
+}
+
+.prow .pop {
+  justify-self: end;
+  align-self: center;
+}
+
+.pnum {
+  text-align: right;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.unit {
+  font-size: var(--sc-xs);
+  font-weight: 400;
+  color: var(--sc-fg3);
+}
+.pnote {
+  min-width: 0;
+  font-size: var(--sc-sm);
+  line-height: 1.35;
+  color: var(--sc-fg3);
+}
+.rowOff .check,
+.rowOff .pnum,
+.rowOff .pnote {
+  color: var(--sc-fg3);
+}
+
+.pexp {
+  justify-self: end;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: none;
+  color: var(--sc-fg3);
+  cursor: pointer;
+}
+.pexp:hover {
+  color: var(--sc-accent);
+}
+.pexp:focus-visible {
+  outline: 2px solid var(--sc-accent);
+  outline-offset: 1px;
+}
+.chev {
+  flex: none;
+  transition: transform 0.12s;
+}
+.chevOpen {
+  transform: rotate(90deg);
+}
+
+.keyRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 3px 0;
+  font-size: var(--sc-xs);
+  color: var(--sc-fg3);
+}
+.keyRow span:first-child {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--sc-fg2);
+}
+.keyRow span:last-child {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+/* ---------- share (bottom band) ---------- */
+
+.share {
+  padding: 16px 22px 18px;
+  border-top: 1px solid var(--sc-line);
+  background: var(--sc-tint);
+}
+
+.summary {
+  margin: 0 0 14px;
+  font-size: var(--sc-md);
+  color: var(--sc-fg);
+}
+.summary b {
+  color: var(--sc-fg);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.shareGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px 32px;
+}
+
+.shareTop {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 7px;
+}
+.shareLabel {
+  font-size: var(--sc-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--sc-fg3);
+}
+.shareVal {
+  text-align: right;
+  font-size: var(--sc-lg);
+  font-weight: 700;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  color: var(--sc-fg);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.shareVal span {
+  font-size: var(--sc-sm);
+  font-weight: 600;
+  color: var(--sc-fg3);
+  letter-spacing: 0;
+}
+
+.shareFoot {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  margin-top: 14px;
+}
+/* reserved so the hover text swapping in cannot reflow the row */
+.shareNote {
+  min-height: 1.3em;
+  font-size: var(--sc-sm);
+  color: var(--sc-fg2);
+  font-variant-numeric: tabular-nums;
+}
+
+.legend {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: var(--sc-xs);
+  color: var(--sc-fg3);
+}
+.legend .dot:nth-of-type(2) {
+  margin-left: 12px;
+}
+.dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex: none;
+}
+
+/* ---------- narrow ---------- */
+
+@container (max-width: 640px) {
+  .controls,
+  .table,
+  .share {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  .thead,
+  .prow {
+    grid-template-columns: minmax(0, 1fr) 5rem 5.4rem 1.6rem;
+  }
+  .thead span:nth-child(2) {
+    display: none;
+  }
+  /* controls drop to their own line under the plane name */
+  .pmid {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+}
+
+/* emphasis-100 sits on top of the page background in dark mode, which would make the
+   tinted bands and every hover state invisible; raise it to the surface there. */
+:global([data-theme="dark"]) .calc {
+  --sc-tint: var(--ifm-background-surface-color);
+}


### PR DESCRIPTION
Adds a production sizing guide to the Platform Engineer Guide (Platform Setup), with an interactive per-plane calculator.

- Field guide: what each plane runs, what drives its size, and HA configuration
- Calculator: workload inputs, optional workflow/observability planes, observability stack picker (OpenSearch, OpenObserve, AWS, Azure, Google Cloud)
- Every figure traces to benchmark measurements, vendor capacity-planning docs, or chart requests

Refs openchoreo/openchoreo#3916