### PR TITLE
chore: update release information for v1.2.3

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ description: Release history for OpenChoreo
 
 | Version     | Date       | Changelog                                                                                 |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------- |
+| v1.2.3      | 2026-08-20 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v123) |
 | v1.2.2      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v122) |
 | v1.2.1      | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v121) |
 | v1.2.0      | 2026-07-24 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v120)         |

--- a/docs/releases/release-and-support-process.md
+++ b/docs/releases/release-and-support-process.md
@@ -30,7 +30,7 @@ Community support is provided for the latest three minor release lines. Publish 
 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
-| v1.2          | 2026-Jul-24 | v1.2.2       | Actively Supported | TBD                     | TBD         |
+| v1.2          | 2026-Jul-24 | v1.2.3       | Actively Supported | TBD                     | TBD         |
 | v1.1          | 2026-May-18 | v1.1.5       | Actively Supported | TBD                     | TBD         |
 | v1.0          | 2026-Mar-23 | v1.0.5       | Actively Supported | TBD                     | TBD         |
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -229,9 +229,9 @@ const config: Config = {
 
   themeConfig: {
     announcementBar: {
-      id: 'release_v1_2_2',
+      id: 'release_v1_2_3',
       content:
-        '🎉️ OpenChoreo <a target="_blank" rel="noopener noreferrer" href="https://github.com/openchoreo/openchoreo/releases/tag/v1.2.2">v1.2.2</a> has been released! 🎉',
+        '🎉️ OpenChoreo <a target="_blank" rel="noopener noreferrer" href="https://github.com/openchoreo/openchoreo/releases/tag/v1.2.3">v1.2.3</a> has been released! 🎉',
       isCloseable: true,
     },
     docsearch: {

--- a/versioned_docs/version-v1.2.x/_constants.mdx
+++ b/versioned_docs/version-v1.2.x/_constants.mdx
@@ -1,9 +1,9 @@
 [//] # (This file stores the constants used across the documentation.)
 
 export const versions = {
-  dockerTag: "v1.2.2",
+  dockerTag: "v1.2.3",
   githubRef: "release-v1.2", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
-  helmChart: "1.2.2",
+  helmChart: "1.2.3",
   helmSource: "oci://ghcr.io/openchoreo/helm-charts",
 };
 

--- a/versioned_docs/version-v1.2.x/changelog.md
+++ b/versioned_docs/version-v1.2.x/changelog.md
@@ -9,6 +9,7 @@ description: Release history for OpenChoreo
 
 | Version     | Date       | Changelog                                                                                 |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------- |
+| v1.2.3      | 2026-08-20 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v123) |
 | v1.2.2      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v122) |
 | v1.2.1      | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v121) |
 | v1.2.0      | 2026-07-24 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v120)         |

--- a/versioned_docs/version-v1.2.x/releases/release-and-support-process.md
+++ b/versioned_docs/version-v1.2.x/releases/release-and-support-process.md
@@ -30,7 +30,7 @@ Community support is provided for the latest three minor release lines. Publish 
 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
-| v1.2          | 2026-Jul-24 | v1.2.2       | Actively Supported | TBD                     | TBD         |
+| v1.2          | 2026-Jul-24 | v1.2.3       | Actively Supported | TBD                     | TBD         |
 | v1.1          | 2026-May-18 | v1.1.5       | Actively Supported | TBD                     | TBD         |
 | v1.0          | 2026-Mar-23 | v1.0.5       | Actively Supported | TBD                     | TBD         |
 


### PR DESCRIPTION
## Purpose

Updates the site for the v1.2.3 patch release, following the same pattern as the v1.2.2 update in 3fb220a6.

The most user-visible part is `versioned_docs/version-v1.2.x/_constants.mdx`: `dockerTag` and `helmChart` feed the install commands in the getting-started guides, so until they are bumped the docs install 1.2.2.

## Approach

- `docs/changelog.md` and `versioned_docs/version-v1.2.x/changelog.md` — add the v1.2.3 row (2026-08-20).
- `versioned_docs/version-v1.2.x/_constants.mdx` — `dockerTag` -> `v1.2.3`, `helmChart` -> `1.2.3`.
- `docusaurus.config.ts` — announcement bar -> v1.2.3.
- `docs/releases/release-and-support-process.md` and the v1.2.x copy — latest patch for the v1.2 line -> v1.2.3.

Smaller than the v1.2.2 update because that one covered three release lines at once (v1.2.2, v1.1.5, v1.0.5). v1.2.3 shipped alone, so the v1.0.x and v1.1.x trees need no change — their changelog tables carry only their own release lines, and their support tables have no v1.2 row.

## Related Issues

Release: openchoreo/openchoreo v1.2.3

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [x] This PR includes AI-generated code or content