### PR TITLE
docs: cover the new component:exec permission in the v1.0 to v1.1 upgrade guide

### DIFF
--- a/docs/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
+++ b/docs/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
@@ -75,6 +75,26 @@ helm upgrade --install observability-metrics-prometheus \
   --set adapter.image.tag=""
 ```
 
+## Authorization: new `component:exec` permission
+
+v1.1 introduces the `component:exec` action, which gates interactive shell access to a running component's pods (`occ component exec` and the Console terminal). It is a new action, so no existing role grants it unless that role uses a wildcard.
+
+In the shipped defaults it was added to the `developer` and `platform-engineer` roles. The `admin` role grants `"*"` and picks it up automatically. Granting it elsewhere is a deliberate choice rather than a step to replicate — exec exposes a workload's environment variables, mounted secrets, and service account token.
+
+| Case                                                   | Result after upgrade                                      | Action required                            |
+| :----------------------------------------------------- | :-------------------------------------------------------- | :----------------------------------------- |
+| **A.** You use the default roles unchanged             | `developer` and `platform-engineer` gain `component:exec` | None                                       |
+| **B.** You override the default roles in Helm values   | Your list is applied as written — exec is **not** added   | Add `component:exec` to your values        |
+| **C.** You define your own roles under different names | Untouched — exec is **not** added                         | Add `component:exec` to your own manifests |
+
+:::warning Wildcard roles gain exec automatically
+Action matching supports verb wildcards, so any role granting `component:*` or `"*"` picks up `component:exec` as soon as the upgrade completes — with no change to your manifests and no review. If you use `component:*` as shorthand for CRUD, enumerate the actions explicitly before upgrading.
+:::
+
+:::note Default roles are re-applied on every upgrade
+The chart upserts its default roles through a `post-install,post-upgrade` hook that runs `kubectl apply` over the manifests rendered from `values.yaml`. The apply does not prune, so roles the chart does not define are left alone — but any role it _does_ define is overwritten from values on every upgrade. Changes made directly against those objects in the cluster do not survive; customize through values (case B) or your own roles (case C) instead.
+:::
+
 ## Multi-cluster: stale `kube-prometheus-stack` values on the data plane
 
 :::warning Data plane upgrade from v1.0.0

--- a/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
+++ b/versioned_docs/version-v1.2.x/platform-engineer-guide/upgrades/v1.0-to-v1.1.mdx
@@ -75,6 +75,26 @@ helm upgrade --install observability-metrics-prometheus \
   --set adapter.image.tag=""
 ```
 
+## Authorization: new `component:exec` permission
+
+v1.1 introduces the `component:exec` action, which gates interactive shell access to a running component's pods (`occ component exec` and the Console terminal). It is a new action, so no existing role grants it unless that role uses a wildcard.
+
+In the shipped defaults it was added to the `developer` and `platform-engineer` roles. The `admin` role grants `"*"` and picks it up automatically. Granting it elsewhere is a deliberate choice rather than a step to replicate — exec exposes a workload's environment variables, mounted secrets, and service account token.
+
+| Case                                                   | Result after upgrade                                      | Action required                            |
+| :----------------------------------------------------- | :-------------------------------------------------------- | :----------------------------------------- |
+| **A.** You use the default roles unchanged             | `developer` and `platform-engineer` gain `component:exec` | None                                       |
+| **B.** You override the default roles in Helm values   | Your list is applied as written — exec is **not** added   | Add `component:exec` to your values        |
+| **C.** You define your own roles under different names | Untouched — exec is **not** added                         | Add `component:exec` to your own manifests |
+
+:::warning Wildcard roles gain exec automatically
+Action matching supports verb wildcards, so any role granting `component:*` or `"*"` picks up `component:exec` as soon as the upgrade completes — with no change to your manifests and no review. If you use `component:*` as shorthand for CRUD, enumerate the actions explicitly before upgrading.
+:::
+
+:::note Default roles are re-applied on every upgrade
+The chart upserts its default roles through a `post-install,post-upgrade` hook that runs `kubectl apply` over the manifests rendered from `values.yaml`. The apply does not prune, so roles the chart does not define are left alone — but any role it _does_ define is overwritten from values on every upgrade. Changes made directly against those objects in the cluster do not survive; customize through values (case B) or your own roles (case C) instead.
+:::
+
 ## Multi-cluster: stale `kube-prometheus-stack` values on the data plane
 
 :::warning Data plane upgrade from v1.0.0


### PR DESCRIPTION
## Purpose

v1.1 introduced the `component:exec` action, which gates interactive shell access to a running component's pods. The v1.0 to v1.1 upgrade guide has no authorization section, so operators upgrading from v1.0 get no indication that the action exists or that they may need to act on it.

This matters most for installations that manage roles declaratively. `component:exec` is added to the shipped `developer` and `platform-engineer` defaults, but a customized role list is applied as written — so the action is silently absent after the upgrade, and users who expect terminal access do not have it.

## Approach

Adds an `## Authorization: new component:exec permission` section, placed after the observability notes and before the multi-cluster section.

The section is deliberately short: a two-paragraph intro, a table of the three cases an operator can be in, and two admonitions.

| Case | Result | Action |
| :--- | :--- | :--- |
| Default roles unchanged | Gains `component:exec` | None |
| Roles overridden in Helm values | Applied as written — not added | Add to values |
| Own separately-named roles | Untouched — not added | Add to your manifests |

The two admonitions cover behaviours an operator has no signal for otherwise:

- **Wildcard roles gain exec automatically.** Action matching supports verb wildcards, so `component:*` or `"*"` picks the action up on upgrade with no manifest change and no review.
- **Default roles are re-applied on every upgrade.** The chart upserts them via a `post-install,post-upgrade` hook running `kubectl apply`; the apply does not prune, so unrelated roles are untouched, but any chart-defined role is overwritten from values. Hand-edits against those objects do not survive.

Applied to both `docs/` and `versioned_docs/version-v1.2.x/`. The versioned copy is the one served at the default `/docs/...` path — a change to `docs/` alone only appears under `/docs/next/`. `version-v1.2.x` is the only versioned tree that carries this guide.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [x] This PR includes AI-generated code or content