### PR TITLE
chore: update release information for v1.1.6

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ description: Release history for OpenChoreo
 | v1.2.2      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v122) |
 | v1.2.1      | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v121) |
 | v1.2.0      | 2026-07-24 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v120)         |
+| v1.1.6      | 2026-08-21 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v116) |
 | v1.1.5      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v115) |
 | v1.1.4      | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v114) |
 | v1.1.3      | 2026-07-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v113) |

--- a/docs/releases/release-and-support-process.md
+++ b/docs/releases/release-and-support-process.md
@@ -31,7 +31,7 @@ Community support is provided for the latest three minor release lines. Publish 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
 | v1.2          | 2026-Jul-24 | v1.2.3       | Actively Supported | TBD                     | TBD         |
-| v1.1          | 2026-May-18 | v1.1.5       | Actively Supported | TBD                     | TBD         |
+| v1.1          | 2026-May-18 | v1.1.6       | Actively Supported | TBD                     | TBD         |
 | v1.0          | 2026-Mar-23 | v1.0.5       | Actively Supported | TBD                     | TBD         |
 
 # Planned Future Minor Releases

--- a/versioned_docs/version-v1.1.x/_constants.mdx
+++ b/versioned_docs/version-v1.1.x/_constants.mdx
@@ -1,9 +1,9 @@
 [//] # (This file stores the constants used across the documentation.)
 
 export const versions = {
-  dockerTag: "v1.1.5",
+  dockerTag: "v1.1.6",
   githubRef: "release-v1.1", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
-  helmChart: "1.1.5",
+  helmChart: "1.1.6",
   helmSource: "oci://ghcr.io/openchoreo/helm-charts",
 };
 

--- a/versioned_docs/version-v1.1.x/changelog.md
+++ b/versioned_docs/version-v1.1.x/changelog.md
@@ -9,6 +9,7 @@ description: Release history for OpenChoreo
 
 | Version        | Date       | Changelog                                                                                 |
 | -------------- | ---------- | ----------------------------------------------------------------------------------------- |
+| v1.1.6        | 2026-08-21 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v116) |
 | v1.1.5        | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v115) |
 | v1.1.4        | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v114) |
 | v1.1.3        | 2026-07-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v113) |

--- a/versioned_docs/version-v1.1.x/releases/release-and-support-process.md
+++ b/versioned_docs/version-v1.1.x/releases/release-and-support-process.md
@@ -30,7 +30,7 @@ Community support is provided for the latest three minor release lines. Publish 
 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
-| v1.1          | 2026-May-18 | v1.1.5      | Actively Supported | TBD                     | TBD         |
+| v1.1          | 2026-May-18 | v1.1.6      | Actively Supported | TBD                     | TBD         |
 | v1.0          | 2026-Mar-23 | v1.0.5      | Actively Supported | TBD                     | TBD         |
 
 # Planned Future Minor Releases

--- a/versioned_docs/version-v1.2.x/releases/release-and-support-process.md
+++ b/versioned_docs/version-v1.2.x/releases/release-and-support-process.md
@@ -31,7 +31,7 @@ Community support is provided for the latest three minor release lines. Publish 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
 | v1.2          | 2026-Jul-24 | v1.2.3       | Actively Supported | TBD                     | TBD         |
-| v1.1          | 2026-May-18 | v1.1.5       | Actively Supported | TBD                     | TBD         |
+| v1.1          | 2026-May-18 | v1.1.6       | Actively Supported | TBD                     | TBD         |
 | v1.0          | 2026-Mar-23 | v1.0.5       | Actively Supported | TBD                     | TBD         |
 
 # Planned Future Minor Releases


### PR DESCRIPTION
## Purpose

Updates the site for the v1.1.6 patch release.

## Approach

- `docs/changelog.md` and `versioned_docs/version-v1.1.x/changelog.md` — add the v1.1.6 row.
- `versioned_docs/version-v1.1.x/_constants.mdx` — `dockerTag` -> `v1.1.6`, `helmChart` -> `1.1.6`.
- `docs/releases/release-and-support-process.md` and the v1.1.x and v1.2.x copies — latest patch for the v1.1 line -> v1.1.6.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [x] This PR includes AI-generated code or content