### PR TITLE
chore: backfill missing patch releases in the v1.2.x changelog table

### DIFF
--- a/versioned_docs/version-v1.2.x/changelog.md
+++ b/versioned_docs/version-v1.2.x/changelog.md
@@ -13,10 +13,15 @@ description: Release history for OpenChoreo
 | v1.2.2      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v122) |
 | v1.2.1      | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v121) |
 | v1.2.0      | 2026-07-24 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v120)         |
+| v1.1.6      | 2026-08-21 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v116) |
+| v1.1.5      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v115) |
+| v1.1.4      | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v114) |
 | v1.1.3      | 2026-07-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v113) |
 | v1.1.2      | 2026-07-08 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v112) |
 | v1.1.1      | 2026-05-29 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.1/CHANGELOG.md#v111) |
 | v1.1.0      | 2026-05-18 | [Changelog](https://github.com/openchoreo/openchoreo/blob/main/CHANGELOG.md#v110)         |
+| v1.0.5      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v105) |
+| v1.0.4      | 2026-07-30 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v104) |
 | v1.0.3      | 2026-07-22 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v103) |
 | v1.0.2      | 2026-07-08 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v102) |
 | v1.0.1      | 2026-05-07 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.0/CHANGELOG.md#v101) |


### PR DESCRIPTION
## Purpose

`versioned_docs/version-v1.2.x/changelog.md` is missing five releases: **v1.0.4, v1.0.5, v1.1.4, v1.1.5 and v1.1.6**. Its v1.1 rows stop at v1.1.3 and its v1.0 rows at v1.0.3.

That file backs the default `/docs/changelog` path, so the published changelog currently skips those releases. `docs/changelog.md` — served at `/docs/next/changelog` — has always been complete, so the two have silently diverged.

Confirmed on the live site after the v1.1.6 docs update merged:

```
/docs/changelog          v1.1.0, v1.1.1, v1.1.2, v1.1.3
/docs/v1.1.x/changelog   v1.1.4, v1.1.5, v1.1.6
```

A reader on the default URL cannot see that v1.1.4, v1.1.5 or v1.1.6 were released at all.

## Approach

Adds the five missing rows, each copied verbatim from `docs/changelog.md` so dates, links and column padding are identical rather than re-derived. After this change the two tables' row sets are byte-identical.

Only the changelog table is touched. The v1.2.x `_constants.mdx` and support tables are unaffected — this does not change which version the v1.2 docs install.

## Related Issues

Follow-up to #834, where this gap was noted but deliberately left out of scope.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [x] This PR includes AI-generated code or content

## Remarks

Verified before raising:

- `diff` of the two tables' row sets returns clean after the change.
- All five backfilled changelog links return HTTP 200.
- Prettier clean against the CI glob.

Likely cause: the per-release docs updates kept the v1.2.x tree's own rows current but not the older lines' rows, so each v1.0.x/v1.1.x patch since v1.2.0 was added to `docs/` and its own versioned tree, but not to v1.2.x. Worth folding into the release-info checklist so it does not drift again.