### PR TITLE
docs: fix install-blocking commands in the v1.1 k3d guide and document the websocket policy

### DIFF
--- a/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-k3d-locally.mdx
+++ b/versioned_docs/version-v1.1.x/getting-started/try-it-out/on-k3d-locally.mdx
@@ -317,6 +317,34 @@ In the `thunder` namespace:
 You can browse and modify the bootstrapped identity configuration (users, groups, OAuth applications) in the ThunderID console at [http://thunder.openchoreo.localhost:8080/console](http://thunder.openchoreo.localhost:8080/console) using `admin` / `admin`. For details on what the bootstrap configured, see the [On Your Environment](on-your-environment.mdx) guide.
 :::
 
+### Enable WebSocket Upgrades (required for `occ component exec`)
+
+`occ component exec` opens a WebSocket connection through the control plane gateway. kgateway rejects WebSocket upgrades unless the listener explicitly allows them, so apply this policy:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: HTTPListenerPolicy
+metadata:
+  name: enable-websocket
+  namespace: openchoreo-control-plane
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: gateway-default
+  upgradeConfig:
+    enabledUpgrades:
+      - websocket
+EOF
+```
+
+:::warning Without this, exec fails with an unhelpful error
+The gateway rejects the upgrade with `403 Forbidden` before the request reaches the API server, so nothing appears in the `openchoreo-api` logs. It looks like a permissions problem, but it is not.
+
+Exec also requires the caller to hold the `component:exec` permission. The default `developer` and `platform-engineer` roles include it, and `admin` inherits it through a wildcard.
+:::
+
 ## Step 4: Install Default Resources
 
 OpenChoreo needs some base resources before you can deploy anything: a project, environments, component types, and a deployment pipeline. These define what kinds of things you can build and where they run.
@@ -375,7 +403,7 @@ The `ClusterDataPlane` resource tells the control plane about this data plane. I
 
 ```bash
 kubectl wait -n openchoreo-data-plane \
-  --for=jsonpath='{.data.ca\.crt}' secret/cluster-agent-tls --timeout=120s
+  --for=condition=Ready certificate/cluster-agent-dataplane-tls --timeout=120s
 
 AGENT_CA=$(kubectl get secret cluster-agent-tls \
   -n openchoreo-data-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
@@ -463,7 +491,7 @@ Build pipelines are defined as ClusterWorkflowTemplates. Each build workflow (do
 
 ```bash
 kubectl wait -n openchoreo-workflow-plane \
-  --for=jsonpath='{.data.ca\.crt}' secret/cluster-agent-tls --timeout=120s
+  --for=condition=Ready certificate/cluster-agent-workflowplane-tls --timeout=120s
 AGENT_CA=$(kubectl get secret cluster-agent-tls \
   -n openchoreo-workflow-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)
 
@@ -608,6 +636,7 @@ helm upgrade --install observability-logs-opensearch \
   --create-namespace \
   --namespace openchoreo-observability-plane \
   --version 0.4.1 \
+  --timeout 15m \
   --set openSearchSetup.openSearchSecretName="opensearch-admin-credentials" \
   --set adapter.openSearchSecretName="opensearch-admin-credentials"
 ```
@@ -652,7 +681,7 @@ helm upgrade observability-logs-opensearch \
 
 ```bash
 kubectl wait -n openchoreo-observability-plane \
-  --for=jsonpath='{.data.ca\.crt}' secret/cluster-agent-tls --timeout=120s
+  --for=condition=Ready certificate/cluster-agent-observabilityplane-tls --timeout=120s
 
 AGENT_CA=$(kubectl get secret cluster-agent-tls \
   -n openchoreo-observability-plane -o jsonpath='{.data.ca\.crt}' | base64 -d)


### PR DESCRIPTION
## Purpose

Found by installing OpenChoreo v1.1.6 on a clean k3d cluster following **only** this guide, applying nothing from outside it. Two of the guide's own commands abort the install, and a third gap leaves `occ component exec` silently broken.

## Approach

**1. `kubectl wait` on a secret that does not exist yet (3 occurrences)**

Each plane's registration step waits for the agent secret:

```bash
kubectl wait -n openchoreo-data-plane \
  --for=jsonpath='{.data.ca\.crt}' secret/cluster-agent-tls --timeout=120s
```

`kubectl wait` fails immediately with `NotFound` when the resource does not exist — it does not wait for it to appear. Immediately after the plane install, cert-manager has not yet produced the secret, so the install aborts:

```
Error from server (NotFound): secrets "cluster-agent-tls" not found
```

Reproduced on two independent clean installs. The secret appeared ~25s later, so this is purely a race the command cannot survive.

Changed to wait on the Certificate, which exists as soon as the chart is applied — the pattern the v1.2 guide already uses:

```bash
kubectl wait -n openchoreo-data-plane \
  --for=condition=Ready certificate/cluster-agent-dataplane-tls --timeout=120s
```

Applied for all three planes, using each plane's actual certificate name (`cluster-agent-dataplane-tls`, `cluster-agent-workflowplane-tls`, `cluster-agent-observabilityplane-tls`).

**2. Logs module install has no `--timeout`**

Its post-install `opensearch-setup-logs` job blocks until OpenSearch is ready, which took **5m48s** here — past Helm's default 5m, so the install failed. The observability plane core install already passes `--timeout 25m`; the logs module was left on the default. Added `--timeout 15m`.

**3. WebSocket upgrades are not documented**

`occ component exec` opens a WebSocket through the control plane gateway, and kgateway rejects upgrades unless the listener allows them. The required `HTTPListenerPolicy` is not in the v1.1 chart and is not mentioned in this guide, so exec does not work after completing it. Verified on the doc-only install:

```
HTTPListenerPolicy in cluster:  No resources found
WebSocket upgrade attempt:      HTTP 403
```

Applying the policy changes that to `101 Switching Protocols`.

Adds a short section at the end of Step 3 with the policy, plus a warning that the failure mode is misleading: the gateway returns `403 Forbidden` before the request reaches the API server, so nothing appears in the `openchoreo-api` logs and it reads as a permissions problem. The note also states that exec requires `component:exec`, which the default `developer` and `platform-engineer` roles carry.

## Related Issues

N/A

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)
- [x] This PR includes AI-generated code or content