### PR TITLE
chore: update docs for v1.2.5 patch release

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ description: Release history for OpenChoreo
 
 | Version     | Date       | Changelog                                                                                 |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------- |
+| v1.2.5      | 2026-09-07 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v125) |
 | v1.2.4      | 2026-08-29 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v124) |
 | v1.2.3      | 2026-08-20 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v123) |
 | v1.2.2      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v122) |

--- a/docs/releases/release-and-support-process.md
+++ b/docs/releases/release-and-support-process.md
@@ -30,7 +30,7 @@ Community support is provided for the latest three minor release lines. Publish 
 
 | Minor release | GA date     | Latest patch | Status             | Maintenance mode starts | End of life |
 | :------------ | :---------- | :----------- | :----------------- | :---------------------- | :---------- |
-| v1.2          | 2026-Jul-24 | v1.2.4       | Actively Supported | TBD                     | TBD         |
+| v1.2          | 2026-Jul-24 | v1.2.5       | Actively Supported | TBD                     | TBD         |
 | v1.1          | 2026-May-18 | v1.1.6       | Actively Supported | TBD                     | TBD         |
 | v1.0          | 2026-Mar-23 | v1.0.5       | Actively Supported | TBD                     | TBD         |
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -229,9 +229,9 @@ const config: Config = {
 
   themeConfig: {
     announcementBar: {
-      id: 'release_v1_2_4',
+      id: 'release_v1_2_5',
       content:
-        '🎉️ OpenChoreo <a target="_blank" rel="noopener noreferrer" href="https://github.com/openchoreo/openchoreo/releases/tag/v1.2.4">v1.2.4</a> has been released! 🎉',
+        '🎉️ OpenChoreo <a target="_blank" rel="noopener noreferrer" href="https://github.com/openchoreo/openchoreo/releases/tag/v1.2.5">v1.2.5</a> has been released! 🎉',
       isCloseable: true,
     },
     docsearch: {

--- a/versioned_docs/version-v1.2.x/_constants.mdx
+++ b/versioned_docs/version-v1.2.x/_constants.mdx
@@ -1,9 +1,9 @@
 [//] # (This file stores the constants used across the documentation.)
 
 export const versions = {
-  dockerTag: "v1.2.4",
+  dockerTag: "v1.2.5",
   githubRef: "release-v1.2", // Used for the GitHub Raw URL references. Example: main, latest, v0.1.0
-  helmChart: "1.2.4",
+  helmChart: "1.2.5",
   helmSource: "oci://ghcr.io/openchoreo/helm-charts",
 };
 

--- a/versioned_docs/version-v1.2.x/changelog.md
+++ b/versioned_docs/version-v1.2.x/changelog.md
@@ -9,6 +9,7 @@ description: Release history for OpenChoreo
 
 | Version     | Date       | Changelog                                                                                 |
 | ----------- | ---------- | ----------------------------------------------------------------------------------------- |
+| v1.2.5      | 2026-09-07 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v125) |
 | v1.2.4      | 2026-08-29 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v124) |
 | v1.2.3      | 2026-08-20 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v123) |
 | v1.2.2      | 2026-08-05 | [Changelog](https://github.com/openchoreo/openchoreo/blob/release-v1.2/CHANGELOG.md#v122) |


### PR DESCRIPTION
## Purpose
Update docs for v1.2.5 patch release

## Related Issues
https://github.com/openchoreo/openchoreo/issues/4635

## Checklist
- [ ] Updated `sidebars.ts` if adding a new documentation page
- [x] Run `npm run start` to preview the changes locally
- [x] Run `npm run build` to ensure the build passes without errors
- [x] Verified all links are working (no broken links)
